### PR TITLE
Turn photoModel into a property and observe it

### DIFF
--- a/FRP/FRPCell.h
+++ b/FRP/FRPCell.h
@@ -12,6 +12,6 @@
 
 @interface FRPCell : UICollectionViewCell
 
--(void)setPhotoModel:(FRPPhotoModel *)photoModel;
+@property (nonatomic, strong) FRPPhotoModel *photoModel;
 
 @end

--- a/FRP/FRPCell.m
+++ b/FRP/FRPCell.m
@@ -30,16 +30,12 @@
     imageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [self.contentView addSubview:imageView];
     self.imageView = imageView;
+
+    RAC(self.imageView, image) = [[RACObserve(self, photoModel.thumbnailData) ignore:nil] map:^(NSData *data) {
+        return [UIImage imageWithData:data];
+    }];
     
     return self;
-}
-
--(void)setPhotoModel:(FRPPhotoModel *)photoModel {
-    RACSignal *prepareForReuseSignal = [self rac_signalForSelector:@selector(prepareForReuse)];
-    
-    RAC(self.imageView, image) = [[[RACObserve(photoModel, thumbnailData) ignore:[NSNull null]] map:^(NSData *data) {
-        return [UIImage imageWithData:data];
-    }] takeUntil:prepareForReuseSignal];
 }
 
 @end


### PR DESCRIPTION
No need to watch for `-prepareForReuse` if the binding can just live as long as the cell itself.
