### PR TITLE
Use -rac_signalForSelector:fromProtocol: directly

### DIFF
--- a/FRP/FRPGalleryViewController.m
+++ b/FRP/FRPGalleryViewController.m
@@ -20,7 +20,7 @@
 
 static NSString *CellIdentifier = @"Cell";
 
-@interface FRPGalleryViewController ()
+@interface FRPGalleryViewController () <FRPFullSizePhotoViewControllerDelegate, UICollectionViewDelegate>
 
 @property (nonatomic, strong) NSArray *photosArray;
 @property (nonatomic, strong) id collectionViewDelegate;
@@ -63,18 +63,15 @@ static NSString *CellIdentifier = @"Cell";
         [self.collectionView reloadData];
     }];
     
-    RACDelegateProxy *viewControllerDelegate = [[RACDelegateProxy alloc] initWithProtocol:@protocol(FRPFullSizePhotoViewControllerDelegate)];
-    
-    [[viewControllerDelegate rac_signalForSelector:@selector(userDidScroll:toPhotoAtIndex:) fromProtocol:@protocol(FRPFullSizePhotoViewControllerDelegate)] subscribeNext:^(RACTuple *value) {
+    [[self rac_signalForSelector:@selector(userDidScroll:toPhotoAtIndex:) fromProtocol:@protocol(FRPFullSizePhotoViewControllerDelegate)] subscribeNext:^(RACTuple *value) {
         @strongify(self);
         [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:[value.second  integerValue] inSection:0] atScrollPosition:UICollectionViewScrollPositionCenteredVertically animated:NO];
     }];
     
-    self.collectionViewDelegate = [[RACDelegateProxy alloc] initWithProtocol:@protocol(UICollectionViewDelegate)];
-    [[self.collectionViewDelegate rac_signalForSelector:@selector(collectionView:didSelectItemAtIndexPath:)] subscribeNext:^(RACTuple *arguments) {
+    [[self rac_signalForSelector:@selector(collectionView:didSelectItemAtIndexPath:) fromProtocol:@protocol(UICollectionViewDelegate)] subscribeNext:^(RACTuple *arguments) {
         @strongify(self);
         FRPFullSizePhotoViewController *viewController = [[FRPFullSizePhotoViewController alloc] initWithPhotoModels:self.photosArray currentPhotoIndex:[(NSIndexPath *)arguments.second item]];
-        viewController.delegate = (id<FRPFullSizePhotoViewControllerDelegate>)viewControllerDelegate;
+        viewController.delegate = self;
         [self.navigationController pushViewController:viewController animated:YES];
     }];
 }


### PR DESCRIPTION
`RACDelegateProxy` is mostly an implementation detail of RAC. `-rac_signalForSelector:fromProtocol:` can be used directly to implement delegate methods.

This code doesn't seem to actually be used yet, so I can't actually test that it works, but it should be the same semantically.
