### PR TITLE
[WIP] Update to iOS 8.

### DIFF
--- a/FRP.xcodeproj/project.pbxproj
+++ b/FRP.xcodeproj/project.pbxproj
@@ -544,7 +544,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -573,7 +572,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -582,7 +581,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -605,7 +603,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -615,14 +612,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7127D6F69C47C55C8935454C /* Pods-FRP.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "FRP/FRP-Prefix.pch";
 				INFOPLIST_FILE = "FRP/FRP-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				VALID_ARCHS = "arm64 armv7 armv7s";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -631,14 +627,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 45B7C6E403355A80BA37853D /* Pods-FRP.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "FRP/FRP-Prefix.pch";
 				INFOPLIST_FILE = "FRP/FRP-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				VALID_ARCHS = "arm64 armv7 armv7s";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -647,7 +642,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3AFF6E7183712769B899335A /* Pods-FRPTests.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/FRP.app/FRP";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -663,7 +657,6 @@
 				INFOPLIST_FILE = "FRPTests/FRPTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
-				VALID_ARCHS = "armv7 armv7s";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
@@ -672,7 +665,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CF7333D7B465DC81C75987DC /* Pods-FRPTests.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/FRP.app/FRP";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -684,7 +676,6 @@
 				INFOPLIST_FILE = "FRPTests/FRPTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
-				VALID_ARCHS = "armv7 armv7s";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;

--- a/Podfile
+++ b/Podfile
@@ -1,15 +1,15 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, "7.0"
+platform :ios, "8.0"
 
 target "FRP" do
 
-pod 'ReactiveCocoa', '2.1.4'
+pod 'ReactiveCocoa'
 pod 'ReactiveViewModel', '0.1.1'
-pod '500px-iOS-api', '1.0.5'
+pod '500px-iOS-api'
 pod 'SVProgressHUD', '1.0'
 pod 'AFImageDownloader', '1.0.0'
-pod 'libextobjc', '0.4'
+pod 'libextobjc'
 
 end
 

--- a/Podfile
+++ b/Podfile
@@ -2,6 +2,8 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, "8.0"
 
+inhibit_all_warnings!
+
 target "FRP" do
 
 pod 'ReactiveCocoa'

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ inhibit_all_warnings!
 target "FRP" do
 
 pod 'ReactiveCocoa'
-pod 'ReactiveViewModel', '0.1.1'
+pod 'ReactiveViewModel', tag: '0.1.2', git: 'https://github.com/ashfurrow/ReactiveViewModel.git'
 pod '500px-iOS-api'
 pod 'SVProgressHUD', '1.0'
 pod 'AFImageDownloader', '1.0.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -59,9 +59,20 @@ DEPENDENCIES:
   - libextobjc
   - OCMock (~> 2.2.2)
   - ReactiveCocoa
-  - ReactiveViewModel (= 0.1.1)
+  - ReactiveViewModel (from `https://github.com/ashfurrow/ReactiveViewModel.git`,
+    tag `0.1.2`)
   - Specta (~> 0.2.1)
   - SVProgressHUD (= 1.0)
+
+EXTERNAL SOURCES:
+  ReactiveViewModel:
+    :git: https://github.com/ashfurrow/ReactiveViewModel.git
+    :tag: 0.1.2
+
+CHECKOUT OPTIONS:
+  ReactiveViewModel:
+    :git: https://github.com/ashfurrow/ReactiveViewModel.git
+    :tag: 0.1.2
 
 SPEC CHECKSUMS:
   500px-iOS-api: d9e46cb6300cef1a12964641374aa467d3cfb891
@@ -71,7 +82,7 @@ SPEC CHECKSUMS:
   libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
   ReactiveCocoa: e2db045570aa97c695e7aa97c2bcab222ae51f4a
-  ReactiveViewModel: 171492c2d30d3eb3c89730fd180c0f6a2ae7e774
+  ReactiveViewModel: 5d852269482387abd4e343cff4c05004967a0707
   Specta: 15a276a6343867b426d5ed135d5aa4d04123a573
   SVProgressHUD: 46088807596a795cbcb4affd92cf3f13b6ab3dda
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,60 +4,61 @@ PODS:
     - Kiwi (~> 1.1.1)
   - Expecta (0.4.2)
   - Kiwi (1.1.1)
-  - libextobjc (0.4):
-    - libextobjc/EXTADT (= 0.4)
-    - libextobjc/EXTConcreteProtocol (= 0.4)
-    - libextobjc/EXTKeyPathCoding (= 0.4)
-    - libextobjc/EXTNil (= 0.4)
-    - libextobjc/EXTSafeCategory (= 0.4)
-    - libextobjc/EXTScope (= 0.4)
-    - libextobjc/EXTSelectorChecking (= 0.4)
-    - libextobjc/EXTSynthesize (= 0.4)
-    - libextobjc/NSInvocation+EXT (= 0.4)
-    - libextobjc/NSMethodSignature+EXT (= 0.4)
-    - libextobjc/RuntimeExtensions (= 0.4)
-    - libextobjc/UmbrellaHeader (= 0.4)
-  - libextobjc/EXTADT (0.4):
+  - libextobjc (0.4.1):
+    - libextobjc/EXTADT (= 0.4.1)
+    - libextobjc/EXTConcreteProtocol (= 0.4.1)
+    - libextobjc/EXTKeyPathCoding (= 0.4.1)
+    - libextobjc/EXTNil (= 0.4.1)
+    - libextobjc/EXTSafeCategory (= 0.4.1)
+    - libextobjc/EXTScope (= 0.4.1)
+    - libextobjc/EXTSelectorChecking (= 0.4.1)
+    - libextobjc/EXTSynthesize (= 0.4.1)
+    - libextobjc/NSInvocation+EXT (= 0.4.1)
+    - libextobjc/NSMethodSignature+EXT (= 0.4.1)
+    - libextobjc/RuntimeExtensions (= 0.4.1)
+    - libextobjc/UmbrellaHeader (= 0.4.1)
+  - libextobjc/EXTADT (0.4.1):
     - libextobjc/RuntimeExtensions
-  - libextobjc/EXTConcreteProtocol (0.4):
+  - libextobjc/EXTConcreteProtocol (0.4.1):
     - libextobjc/RuntimeExtensions
-  - libextobjc/EXTKeyPathCoding (0.4):
+  - libextobjc/EXTKeyPathCoding (0.4.1):
     - libextobjc/RuntimeExtensions
-  - libextobjc/EXTNil (0.4):
+  - libextobjc/EXTNil (0.4.1):
     - libextobjc/RuntimeExtensions
-  - libextobjc/EXTSafeCategory (0.4):
+  - libextobjc/EXTSafeCategory (0.4.1):
     - libextobjc/RuntimeExtensions
-  - libextobjc/EXTScope (0.4):
+  - libextobjc/EXTScope (0.4.1):
     - libextobjc/RuntimeExtensions
-  - libextobjc/EXTSelectorChecking (0.4):
+  - libextobjc/EXTSelectorChecking (0.4.1):
     - libextobjc/RuntimeExtensions
-  - libextobjc/EXTSynthesize (0.4):
+  - libextobjc/EXTSynthesize (0.4.1):
     - libextobjc/RuntimeExtensions
-  - libextobjc/NSInvocation+EXT (0.4):
+  - libextobjc/NSInvocation+EXT (0.4.1):
     - libextobjc/RuntimeExtensions
-  - libextobjc/NSMethodSignature+EXT (0.4):
+  - libextobjc/NSMethodSignature+EXT (0.4.1):
     - libextobjc/RuntimeExtensions
-  - libextobjc/RuntimeExtensions (0.4)
-  - libextobjc/UmbrellaHeader (0.4)
+  - libextobjc/RuntimeExtensions (0.4.1)
+  - libextobjc/UmbrellaHeader (0.4.1)
   - OCMock (2.2.4)
-  - ReactiveCocoa (2.1.4):
-    - ReactiveCocoa/Core (= 2.1.4)
-    - ReactiveCocoa/no-arc (= 2.1.4)
-  - ReactiveCocoa/Core (2.1.4):
+  - ReactiveCocoa (2.5):
+    - ReactiveCocoa/UI (= 2.5)
+  - ReactiveCocoa/Core (2.5):
     - ReactiveCocoa/no-arc
-  - ReactiveCocoa/no-arc (2.1.4)
+  - ReactiveCocoa/no-arc (2.5)
+  - ReactiveCocoa/UI (2.5):
+    - ReactiveCocoa/Core
   - ReactiveViewModel (0.1.1):
     - ReactiveCocoa (~> 2.1)
   - Specta (0.2.1)
   - SVProgressHUD (1.0)
 
 DEPENDENCIES:
-  - 500px-iOS-api (= 1.0.5)
+  - 500px-iOS-api
   - AFImageDownloader (= 1.0.0)
   - Expecta (~> 0.2)
-  - libextobjc (= 0.4)
+  - libextobjc
   - OCMock (~> 2.2.2)
-  - ReactiveCocoa (= 2.1.4)
+  - ReactiveCocoa
   - ReactiveViewModel (= 0.1.1)
   - Specta (~> 0.2.1)
   - SVProgressHUD (= 1.0)
@@ -67,11 +68,11 @@ SPEC CHECKSUMS:
   AFImageDownloader: 90fe0794cc3577ff30ca7fbbab8cf19235578aa3
   Expecta: 78b4e8b0c8291fa4524d7f74016b6065c2e391ec
   Kiwi: 4e1a4bcc164fa7c8de649fe545c6d681c01b441c
-  libextobjc: f2802d4262f6885570df9799747409ceb1de602c
+  libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
-  ReactiveCocoa: 12072a1a4768b988f1f5a0a8c171c96bf021c2ff
+  ReactiveCocoa: e2db045570aa97c695e7aa97c2bcab222ae51f4a
   ReactiveViewModel: 171492c2d30d3eb3c89730fd180c0f6a2ae7e774
   Specta: 15a276a6343867b426d5ed135d5aa4d04123a573
   SVProgressHUD: 46088807596a795cbcb4affd92cf3f13b6ab3dda
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.38.2


### PR DESCRIPTION
Fixes #42.

Currently, ReactiveCocoa isn't building, though:

```
/Users/ash/bin/FunctionalReactivePixels/Pods/Headers/Private/ReactiveCocoa/RACQueueScheduler+Subclass.h:19:1: 
Property with 'retain (or strong)' attribute must be of object type
```
