### PR TITLE
reset the imageView.image before the collectionViewCell reuse

### DIFF
--- a/FRP/FRPCell.m
+++ b/FRP/FRPCell.m
@@ -42,6 +42,10 @@
 			return nil;
 		}] subscribeOn:[RACScheduler scheduler]];
 	}] switchToLatest];
+    
+    [self.rac_prepareForReuseSignal subscribeNext:^(id x) {
+        self.imageView.image = nil;
+    }];
 	
     return self;
 }


### PR DESCRIPTION
if u don't reset the image of imageView before reusing the cell, sometimes you could find same images always appear in gallery view after u scrolled the collectionView fast , especially if the network is slow.